### PR TITLE
Adding base_dir to adjust_cwl_docker_tags to be callable from Airflow

### DIFF
--- a/hubmap_pipeline_release_mgmt/tag_release_pipeline.py
+++ b/hubmap_pipeline_release_mgmt/tag_release_pipeline.py
@@ -95,9 +95,9 @@ DO_NOT_SIGN = object()
 SIGN_WITH_DEFAULT_IDENTITY = object()
 
 
-def adjust_cwl_docker_tags(tag_without_v: str,
-                           pretend: bool = False,
-                           base_dir: Path = Path()) -> bool:
+def adjust_cwl_docker_tags(
+    tag_without_v: str, pretend: bool = False, base_dir: Path = Path()
+) -> bool:
     docker_images = read_images(base_dir)
     labels = set(label for label, path, options in docker_images)
 

--- a/hubmap_pipeline_release_mgmt/tag_release_pipeline.py
+++ b/hubmap_pipeline_release_mgmt/tag_release_pipeline.py
@@ -95,8 +95,10 @@ DO_NOT_SIGN = object()
 SIGN_WITH_DEFAULT_IDENTITY = object()
 
 
-def adjust_cwl_docker_tags(tag_without_v: str, pretend: bool = False) -> bool:
-    docker_images = read_images(Path())
+def adjust_cwl_docker_tags(tag_without_v: str,
+                           pretend: bool = False,
+                           base_dir: Path = Path()) -> bool:
+    docker_images = read_images(base_dir)
     labels = set(label for label, path, options in docker_images)
 
     adjustment_performed = False


### PR DESCRIPTION
Adding base_dir to adjust_cwl_docker_tags to be callable from Airflow and passed the path of the docker images, defaulting to current path for the cli calls